### PR TITLE
Support specifying the device type

### DIFF
--- a/awair.py
+++ b/awair.py
@@ -7,7 +7,7 @@ class awair:
     self.username = username
     self.password = password
 
-    if not access_token: 
+    if not access_token:
       self.login()
     else:
       self.access_token = access_token
@@ -57,18 +57,18 @@ class awair:
     contents = self.make_request(url, method="GET")
     return contents
 
-  def events_score(self, device_id, desc="true", limit="1"):
-    url = "https://internal.awair.is/v1/devices/awair/"+str(device_id)+"/events/score?desc="+desc+"&limit="+ limit
+  def events_score(self, device_id, device_type, desc="true", limit="1"):
+    url = "https://internal.awair.is/v1/devices/"+device_type+"/"+str(device_id)+"/events/score?desc="+desc+"&limit="+ limit
     events = self.make_request(url, method="GET")
     return events
 
-  def timeline(self, device_id, from_timestamp, to_timestamp):
-    url = "https://internal.awair.is/v1.2/devices/awair/"+str(device_id)+"/timeline?from="+from_timestamp+"&to="+to_timestamp
+  def timeline(self, device_id, device_type, from_timestamp, to_timestamp):
+    url = "https://internal.awair.is/v1.2/devices/"+device_type+"/"+str(device_id)+"/timeline?from="+from_timestamp+"&to="+to_timestamp
     timeline = self.make_request(url, method="GET")
     return timeline
 
-  def sleep_report(self, device_id, timestamp, lang="en" ):
-    url = "https://internal.awair.is/v1.2/users/self/devices/awair/"+str(device_id)+"/sleep-report?lang="+lang+"&timestamp="+timestamp
+  def sleep_report(self, device_id, device_type, timestamp, lang="en" ):
+    url = "https://internal.awair.is/v1.2/users/self/devices/"+device_type+"/"+str(device_id)+"/sleep-report?lang="+lang+"&timestamp="+timestamp
     timeline = self.make_request(url, method="GET")
     return timeline
 

--- a/example.py
+++ b/example.py
@@ -9,29 +9,29 @@ if __name__ == "__main__":
     api =  awair(username, password) #Let's authenticate
 
     devices = api.devices() #Grab the devices that are on your account
-    
-    today = datetime.datetime.today() 
+
+    today = datetime.datetime.today()
     yesterday = today - datetime.timedelta(days=1)
 
     for device in devices:  #Let's iterate through devices
-      print(device) #Print the device 
+      print(device) #Print the device
 
       print("Let's grab the weather")
       print(api.weather(latitude=device['latitude'],longitude=device['longitude']))
 
       print("Timeline from yesterday to today")
-      print(api.timeline(device['id'], str(yesterday.isoformat()), str(today.isoformat())))
-      
+      print(api.timeline(device['id'], device['type'], str(yesterday.isoformat()), str(today.isoformat())))
+
       print("Event score")
-      print api.events_score(device['id'])
-      
+      print(api.events_score(device['id'], device['type']))
+
       device_id = device['id'] #Store the last device id for the next part
 
 
     inbox = api.inbox() #Grab inbox
     for message in inbox: #iterate through messages in inbox
-      print message #Print the message
-      
+      print(message) #Print the message
+
       if message['title']=='Sleep Report':
         print("Printing sleep report for " + message['timestamp'])
-        print(api.sleep_report(device_id, message['timestamp']))
+        print(api.sleep_report(device_id, device['type'], message['timestamp']))


### PR DESCRIPTION
I have an Awair Glow, and only some of the API calls were working for me. I tracked it down to the device needing to be set correctly (using `awair-glow` and not `awair`). This uses the device type provided by the `users/self/devices` call in the device-specific api calls.